### PR TITLE
Allow rendering menu in separate plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,17 @@ to settings.MIGRATION_MODULES
 1. Add a Section Container plugin to the page;
 2. Add one or more Section plugins into the Section Container;
 3. Add content to each Section plugin as per usual;
-4. Optionally render the menu in a separate plugin by clicking "Create Menu"
-   from the Section Container's menu in structure mode;
 4. Style with CSS to suit your needs;
 5. Optionally add the above JS to your project to provide smooth scrolling
    between sections;
 6. Optionally override or extend the provided templates to further suit your
    needs.
 
+### Rendering the menu separately
+
+The menu plugin works much like the Alias plugin. Click "Create Menu"
+from the Section Container's menu in structure mode. It then goes to
+the clipboard and can be dragged from there to anywhere.
 
 ## ADVANCED USAGE
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 cmsplugin-sections
 ==================
 
-This is a plugin "system" (really just two) for making "single-page scroller"
+This is a plugin "system" (really just three) for making "single-page scroller"
 websites super easy.
 
-It provides a Section Container plugin and a generic Section plugin out of the
-box. Section Containers allow Section plugins to be added inside them. Section
-plugins will allow anything inside them, but have some basic configuration of
-their own, namely:
+It provides a Section Container plugin, a generic Section plugin and an
+optional Sections Menu plugin out of the box. Section Containers allow
+Section plugins to be added inside them. Section plugins will allow anything
+inside them, but have some basic configuration of their own, namely:
 
 1. Title - The title of the section;
 
@@ -22,12 +22,14 @@ their own, namely:
 
 
 The Section Container will render all of its children plugins, but first, it
-will emit basic menu markup of the contained sections.
+will emit basic menu markup of the contained sections. You can also choose to
+render the menu separately in an another plugin if you need to place it
+somewhere else.
 
 Now your operators can move sections around, and the in-page menu will stay up
 to date.
 
-For your section-linking convenience, each Section plugin will also emit links
+For your section-linking convenience, each Section plugin can also emit links
 to the previous and next sections, if present.
 
 You will need to provide some CSS styling and possibly some JS for nice,
@@ -40,7 +42,7 @@ that use jQuery:
     //
     // Provide graceful scrolling around the page
     //
-    $("nav.page").on('click', 'a', function(evt) {
+    $("nav.section-menu").on('click', 'a', function(evt) {
       var $this = $(this),
           target = $this.attr('href');
 
@@ -74,10 +76,12 @@ to settings.MIGRATION_MODULES
 1. Add a Section Container plugin to the page;
 2. Add one or more Section plugins into the Section Container;
 3. Add content to each Section plugin as per usual;
-4. Style with CSS to suite your needs;
+4. Optionally render the menu in a separate plugin by clicking "Create Menu"
+   from the Section Container's menu in structure mode;
+4. Style with CSS to suit your needs;
 5. Optionally add the above JS to your project to provide smooth scrolling
    between sections;
-6. Optionally override or extend the provided templates to further suite your
+6. Optionally override or extend the provided templates to further suit your
    needs.
 
 
@@ -89,9 +93,9 @@ operators to choose from. However, there may be some cases where it makes
 sense to just create a custom Section plugin.
 
 Both the Section Container and the Section plugin were built in a manner that
-provides easy extention via subclassing a "base" plugin and a "base" plugin
+provides easy extension via subclassing a "base" plugin and a "base" plugin
 model. This makes it pretty straightforward to create your own, pluggable
-sections types for your operators.
+section types for your operators.
 
 If you plan to create your own, custom Sections for your project, your
 `models.py` might looks something like this:
@@ -102,15 +106,15 @@ from cmsplugin_sections.models import AbstractSectionBasePluginModel
 
 class SplashSectionPluginModel(AbstractSectionBasePluginModel):
 	#
-    # Include project-specific Section Plugin configuration here. Or not. See
-	# note below.
+    # Include project-specific Section Plugin configuration here. Or not.
+	# See note below.
 	#
     pass
 
 ````
 
 NOTE:
-	
+
 	If is entirely optional to create your own pluginmodel if you don't need
 	to add configuration options. You *could* just use the provided one, but,
 	if you ever change your mind, it will be rather complicated to migrate any
@@ -123,8 +127,8 @@ NOTE:
 Your `cms_plugins.py` might look like this:
 
 ```` python
-from cmsplugin_sections.cms_plugins import BaseSectionPlugin
 # Assumes models.py and cms_plugins.py are at the same level in your project.
+from .cms_plugins import BaseSectionPlugin
 from .models import SplashSectionPluginModel
 
 class SplashSectionPlugin(BaseSectionPlugin):

--- a/cmsplugin_sections/migrations_django/0002_auto_20150308_1319.py
+++ b/cmsplugin_sections/migrations_django/0002_auto_20150308_1319.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0003_auto_20140926_2347'),
+        ('cmsplugin_sections', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SectionsMenuPluginModel',
+            fields=[
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('plugin', models.ForeignKey(related_name='container_reference', editable=False, to='cms.CMSPlugin', null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('cms.cmsplugin',),
+        ),
+        migrations.RemoveField(
+            model_name='sectioncontainerpluginmodel',
+            name='subordinate_page',
+        ),
+        migrations.AddField(
+            model_name='sectioncontainerpluginmodel',
+            name='menu',
+            field=models.BooleanField(default=True, help_text='The menu can be rendered separately in another plugin. Useful for placement in another placeholder.', verbose_name='include menu?'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='sectioncontainerpluginmodel',
+            name='section_links',
+            field=models.BooleanField(default=True, help_text='Provides convenient linking between sections by adding links to next and previous sections in each.', verbose_name='include section links?'),
+            preserve_default=True,
+        ),
+    ]

--- a/cmsplugin_sections/models.py
+++ b/cmsplugin_sections/models.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible  #, force_text
+from django.utils.encoding import python_2_unicode_compatible, force_text
 from django.utils.translation import ugettext_lazy as _
 
 from .unique_slugify import unique_slugify
@@ -18,7 +18,10 @@ class AbstractSectionContainerPluginModel(CMSPlugin):
 
 
 class SectionContainerPluginModel(AbstractSectionContainerPluginModel):
-    subordinate_page = models.BooleanField(_('subordinate_page?'), default=False)
+    menu = models.BooleanField(_('include menu?'), default=True,
+        help_text=_('The menu can be rendered separately in another plugin. Useful for placement in another placeholder.'))
+    section_links = models.BooleanField(_('include section links?'), default=True,
+        help_text=_('Provides convenient linking between sections by adding links to next and previous sections in each.'))
 
 
 @python_2_unicode_compatible
@@ -84,5 +87,17 @@ class SectionBasePluginModel(AbstractSectionBasePluginModel):
     """
     Defines a common interface for section plugins.
     """
-    
+
     taints_cache = True
+
+
+@python_2_unicode_compatible
+class SectionsMenuPluginModel(CMSPlugin):
+    plugin = models.ForeignKey(CMSPlugin, editable=False, related_name="container_reference", null=True)
+
+    def __str__(self):
+        if self.plugin_id:
+            return "(%s) %s" % (force_text(self.plugin.get_plugin_name()), self.plugin.get_plugin_instance()[0])
+        else:
+            return force_text(self.alias_placeholder.get_label())
+

--- a/cmsplugin_sections/templates/cmsplugin_sections/section-base.html
+++ b/cmsplugin_sections/templates/cmsplugin_sections/section-base.html
@@ -1,12 +1,11 @@
-<section id="{{ instance.section_menu_slug }}">
-  <div class="outer">
-    <div class="inner">
-      {% block section_content %}
-      {% endblock %}{% if prev or next %}
-      <div class="section-links">
-        {% if prev %}<a class="prev" href="#{{ prev.section_menu_slug }}">{{ prev.section_menu_label }}</a>{% endif %}
-        {% if next %}<a class="next" href="#{{ next.section_menu_slug }}">{{ next.section_menu_label }}</a>{% endif %}
-      </div>{% endif %}
-    </div>
-  </div>
-</section>
+<article id="{{ instance.section_menu_slug }}">
+  {% if instance.show_title %}<h2>{{ instance.section_title }}</h2>{% endif %}
+  {% block section_content %}
+  {% endblock %}{% if prev or next %}
+  <div class="section-links">
+    <ul>
+      {% if prev %}<li class="prev"><a href="#{{ prev.section_menu_slug }}">{{ prev.section_menu_label }}</a></li>{% endif %}
+      {% if next %}<li class="next"><a href="#{{ next.section_menu_slug }}">{{ next.section_menu_label }}</a></li>{% endif %}
+    </ul>
+  </div>{% endif %}
+</article>

--- a/cmsplugin_sections/templates/cmsplugin_sections/section-children.html
+++ b/cmsplugin_sections/templates/cmsplugin_sections/section-children.html
@@ -1,0 +1,6 @@
+{% load cms_tags %}
+{% for child_section in children %}
+  {% with next=child_section.next prev=child_section.prev %}
+  {% render_plugin child_section.child  %}
+  {% endwith %}
+{% endfor %}

--- a/cmsplugin_sections/templates/cmsplugin_sections/section-container.html
+++ b/cmsplugin_sections/templates/cmsplugin_sections/section-container.html
@@ -1,18 +1,9 @@
-{% load cms_tags %}
+{% if sections %}
 <header class="page">
-  <a class="logo" href="/#{{ sections.0.section_menu_slug }}"><img src=""></a>
-  <nav class="page">
-    <div class="menu">
-      <ul class="section-menu">{% for section in sections %}
-        <li><a href="#{{ section.section_menu_slug }}">{{ section.section_menu_label }}</a></li>{% endfor %}
-      </ul>
-    </div>
-  </nav>
+  <a class="logo" href="#{{ sections.0.section_menu_slug }}"></a>
+  {% include 'cmsplugin_sections/section-menu.html' %}
 </header>
-<div>
-  {% for child_section in children %}
-    {% with next=child_section.next prev=child_section.prev %}
-    {% render_plugin child_section.child  %}
-    {% endwith %}
-  {% endfor %}
-</div>
+{% endif %}
+<main>
+  {% include 'cmsplugin_sections/section-children.html' %}
+</main>

--- a/cmsplugin_sections/templates/cmsplugin_sections/section-menu.html
+++ b/cmsplugin_sections/templates/cmsplugin_sections/section-menu.html
@@ -1,0 +1,9 @@
+<nav class="section-menu">
+  <ul>
+  {% for section in sections %}
+    {% if section.show_in_menu %}
+    <li><a href="#{{ section.section_menu_slug }}">{{ section.section_menu_label }}</a></li>
+    {% endif %}
+  {% endfor %}
+  </ul>
+</nav>


### PR DESCRIPTION
These are some changes that I wanted to make for my project (#1), mainly to allow rendering the menu separately. I also went ahead and moved some of what I had in my overriden templates to the default templates, to have less and more semantic markup.
#### What can break for existing installations?
- Default markup has changed, so for those who don't have an override, it will have to be done now;
- I found I had to re-save my container plugin;

Appart from that, should work as it has.
#### Model changes
- When installing the app for the first time, not requiring to override a template, I found it better to have a choice as to printing next/prev links, as well as the menu, because I want it in a sidebar, and be able to add social icons below it.
- I removed the `subordinate_page` in `SectionContainerPluginModel` because it wasn't being used anywhere.
- The menu functionality works with any implementation of the abstract container, because I'm checking for the abstract.
#### HTML markup changes
- `<article>` is actually a specific kind of `<section>` for a "thing" that stands on it's own (like in an RSS feed item). I think it's a more semantic choice;
- `<main>` should be used for the page's main content, and should only be used once;
- Added an `<h2>` heading to section titles, if they exist;
- Removed some HTML elements to provide de minimum. It's actually all I need in my project.

In my project I've overriden `section-container.html` to contain only this line: 

```
{% include 'cmsplugin_sections/section-children.html' %}
```

That's because I want that default structure in my project's `base.html`, and still allow a default installation to give all that you need.
#### Other changes
- Passing strings through gettext to allow for translation.
- I'm sending all sections to the template and let it decide in the menu if it's to be shown or not. In my project the link in the logo wasn't working because my first item isn't in the menu. I use the logo as the first item.
