### PR TITLE
fixes TypeError when creating new empty SectionContainer plugins

### DIFF
--- a/cmsplugin_sections/cms_plugins.py
+++ b/cmsplugin_sections/cms_plugins.py
@@ -33,21 +33,22 @@ class SectionContainerPlugin(CMSPluginBase):
 
         children = []
 
-        for i, child in enumerate(instance.child_plugin_instances):
-            prev_child = None
-            next_child = None
+        if instance.child_plugin_instances is not None:
+            for i, child in enumerate(instance.child_plugin_instances):
+                prev_child = None
+                next_child = None
 
-            if i > 0:
-                prev_child = instance.child_plugin_instances[i-1]
+                if i > 0:
+                    prev_child = instance.child_plugin_instances[i-1]
 
-            if i < len(instance.child_plugin_instances) - 1:
-                next_child = instance.child_plugin_instances[i+1]
+                if i < len(instance.child_plugin_instances) - 1:
+                    next_child = instance.child_plugin_instances[i+1]
 
-            children.append({
-                'prev': prev_child,
-                'child': child,
-                'next': next_child,
-            })
+                children.append({
+                    'prev': prev_child,
+                    'child': child,
+                    'next': next_child,
+                })
 
         return children
 
@@ -55,9 +56,10 @@ class SectionContainerPlugin(CMSPluginBase):
 
         section_menu_items = []
 
-        for child in instance.child_plugin_instances:
-            if child.show_in_menu:
-                section_menu_items.append(child)
+        if instance.child_plugin_instances is not None:
+            for child in instance.child_plugin_instances:
+                if child.show_in_menu:
+                    section_menu_items.append(child)
 
         context['children'] = self.get_children(instance)
         context['sections'] = section_menu_items

--- a/cmsplugin_sections/cms_plugins.py
+++ b/cmsplugin_sections/cms_plugins.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from cms.models import CMSPlugin
 from cms.plugin_pool import plugin_pool
 from cms.plugin_base import CMSPluginBase
+from django.conf import settings
 
 from .models import SectionBasePluginModel
 
@@ -17,7 +18,9 @@ class SectionContainerPlugin(CMSPluginBase):
     allow_children = True
     cache = True
     # TODO: Complete this, or set it in settings.
-    # child_classes = ['...']
+    # Is anything wrong with just allowing SectionPlugins here?
+    # Other section plugin subclasses should be 
+    child_classes = getattr(settings, 'CMSPLUGIN_SECTIONS_CONTAINER_CHILD_CLASSES', ['SectionPlugin', ])
     model = CMSPlugin
     module = 'Sections'
     name = 'Section Container'


### PR DESCRIPTION
As I've promised here's a little fix that prevents an Error when trying to iterate over non-existent Sections.
